### PR TITLE
Fix blob error for single pixels

### DIFF
--- a/machinevisiontoolbox/ImageBlobs.py
+++ b/machinevisiontoolbox/ImageBlobs.py
@@ -237,7 +237,8 @@ class Blobs(UserList):  # lgtm[py/missing-equals]
 
             blob.contourpoint = blob.perimeter[:, 0]
 
-            ## append the new Blob instance only if the area is greater than 0
+            ## For a single set pixel OpenCV returns all moments as zero, skip such blobs
+            ## TODO handle this situation by setting m00=1, m10=x, m01=y etc.
             if blob.moments["m00"] != 0:
                 self.data.append(blob)
 

--- a/machinevisiontoolbox/ImageBlobs.py
+++ b/machinevisiontoolbox/ImageBlobs.py
@@ -237,8 +237,9 @@ class Blobs(UserList):  # lgtm[py/missing-equals]
 
             blob.contourpoint = blob.perimeter[:, 0]
 
-            ## append the new Blob instance
-            self.data.append(blob)
+            ## append the new Blob instance only if the area is greater than 0
+            if blob.moments["m00"] != 0:
+                self.data.append(blob)
 
         ## second pass: equivalent ellipse
 


### PR DESCRIPTION
Some blobs were being created that were one pixel in size causing the code:

`blob.uc = M.m10 / M.m00`

for the centroid to throw a division by zero error.

Added in code to prevent the blob being appended when the value of m00 is zero