### PR TITLE
feat(mvtbtool): add 'tool' extra for IPython/pygments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
             wcwidth
             tqdm
             hatchling
+            ipython
+            pygments
 
       - name: Install libegl (Linux)
         if: runner.os == 'Linux'
@@ -85,6 +87,8 @@ jobs:
             wcwidth
             tqdm
             hatchling
+            ipython
+            pygments
 
       - name: Install libegl
         run: micromamba install -y -n myenv -c conda-forge libegl

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -96,6 +96,9 @@ The available extras are:
 +--------------+-------------------------------------------+
 | ``labelme``  | LabelMe JSON annotation reader support    |
 +--------------+-------------------------------------------+
+| ``tool``     | ``IPython`` and ``pygments``, needed to   |
+|              | run the ``mvtbtool`` interactive shell    |
++--------------+-------------------------------------------+
 | ``all``      | All of the above                          |
 +--------------+-------------------------------------------+
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,13 @@ dependencies = [
 #  open3d - open3d support (open3d generally won't work with latest Python)
 #  all - all runtime optional features below
 #  ocr - OCR support via pytesseract
+#  tool - dependencies for the mvtbtool interactive shell
 
 dev = ["pytest", "coverage", "ruff", "nbmake"]
 
 ros = ["rosbags", "roslibpy", "websockets"]
+
+tool = ["ipython", "pygments"]
 
 docs = [
     "sphinx",
@@ -98,6 +101,8 @@ all = [
     "rosbags",
     "roslibpy",
     "websockets",
+    "ipython",
+    "pygments",
 ]
 
 [tool.pytest.ini_options]

--- a/src/machinevisiontoolbox/bin/mvtbtool.py
+++ b/src/machinevisiontoolbox/bin/mvtbtool.py
@@ -261,6 +261,18 @@ func/object??      - show source code"""
 
 
 def main():
+    try:
+        import IPython
+        from IPython.terminal.prompts import Prompts
+        from pygments.token import Token
+        from traitlets.config import Config
+    except ImportError as e:
+        sys.exit(
+            f"mvtbtool requires IPython and pygments, which are not "
+            f"installed ({e}).\nInstall them with:\n\n"
+            "    pip install machinevision-toolbox-python[tool]\n"
+        )
+
     args, ipython_args = parse_arguments()
     torch_modules, torch_warnings = optional_torch_imports(args.torch)
 
@@ -281,11 +293,6 @@ def main():
     #     exec(path.read_text())
 
     ## drop into IPython
-    import IPython
-    from IPython.terminal.prompts import ClassicPrompts, Prompts
-    from pygments.token import Token
-    from traitlets.config import Config
-
     class MyPrompt(Prompts):
         def in_prompt_tokens(self, cli=None):
             return [(Token.Prompt, args.prompt)]


### PR DESCRIPTION
## Summary
- `mvtbtool` imports `IPython`, `pygments`, and `traitlets` inside `main()`, but none were declared as a dependency anywhere — `pip install machinevision-toolbox-python` followed by running `mvtbtool` crashed with a raw `ModuleNotFoundError` unless IPython happened to already be present transitively (e.g. via Jupyter). Same gap found and fixed in roboticstoolbox-python's `rtbtool` (companion PR).
- Wrapped the imports in a try/except that points the user at a new `tool` extra (`pip install machinevision-toolbox-python[tool]`) instead of a bare traceback.
- Added `tool = ["ipython", "pygments"]` to `pyproject.toml`, folded into `all`, and documented in `docs/source/installation.rst`'s extras table alongside the existing `ros`/`jupyter`/`torch` extras.

## Test plan
- [x] Simulated missing IPython/pygments → clean error message pointing at `pip install machinevision-toolbox-python[tool]`
- [x] Normal run (`python -m machinevisiontoolbox.bin.mvtbtool`) still drops into an IPython shell correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)