### PR TITLE
fix: use eigh instead of eig for blob orientation/ellipse moments

### DIFF
--- a/src/machinevisiontoolbox/ImageBlobs.py
+++ b/src/machinevisiontoolbox/ImageBlobs.py
@@ -458,7 +458,10 @@ class Blobs(UserList):  # lgtm[py/missing-equals]
 
                 ## Equivalent ellipse
                 J = np.array([[M["mu20"], M["mu11"]], [M["mu11"], M["mu02"]]])
-                e, X = np.linalg.eig(J)
+                # J is real-symmetric, so use eigh (not eig): eig can return
+                # complex128 for a symmetric matrix due to floating-point
+                # noise even though the eigenvalues are mathematically real.
+                e, X = np.linalg.eigh(J)
                 blob_params["a"] = 2.0 * np.sqrt(e.max() / M["m00"])
                 blob_params["b"] = 2.0 * np.sqrt(e.min() / M["m00"])
 

--- a/tests/test_image_blobs.py
+++ b/tests/test_image_blobs.py
@@ -119,6 +119,23 @@ class TestBlobs(unittest.TestCase):
         self.assertEqual(blobs[1].area, 4)
         self.assertEqual(blobs[1].perimeter_length, 7)
 
+    def test_orientation_square_blob_degenerate_moments(self):
+        # A square (or any blob with equal mu20/mu02 and mu11≈0) has a
+        # moment matrix that is a scalar multiple of the identity: its two
+        # eigenvalues are exactly equal. np.linalg.eig (general, non-
+        # symmetric solver) can return complex128 for this case due to
+        # floating-point noise even though the matrix is real-symmetric and
+        # the eigenvalues are mathematically real, which then makes
+        # np.arctan2() raise TypeError. np.linalg.eigh (symmetric solver)
+        # does not have this failure mode. See ImageBlobs.py's equivalent
+        # ellipse / orientation calculation.
+        im = Image.Squares(1, size=61, fg=255, bg=0)
+        blobs = im.blobs()
+
+        orientation = blobs[0].orientation
+        self.assertIsInstance(orientation, float)
+        self.assertFalse(np.iscomplexobj(orientation))
+
 
 # ============================================================================ #
 #  Fixtures


### PR DESCRIPTION
## Summary
- `Image.blobs()` computed the blob's second-moment matrix eigendecomposition with `np.linalg.eig`, the general non-symmetric solver. That matrix is always real-symmetric, but for degenerate cases (a square blob, or any near-circular blob where both eigenvalues are equal — e.g. `Image.Squares(...)`) `eig` can return `complex128` output purely from floating-point noise. `np.arctan2()` then raised `TypeError`, crashing `blobs()` outright for these shapes.
- Switched to `np.linalg.eigh`, the correct solver for symmetric matrices, which always returns real output.
- Added a regression test (`test_orientation_square_blob_degenerate_moments`) documenting the failure mode. The existing `TestBlobScalarProperties::test_orientation` also already exercised this via the `Image.Squares(1, ...)` fixture and was failing before this fix on this machine (Apple Silicon / Accelerate BLAS) — may not have surfaced on CI depending on the LAPACK backend there.
- Found via unrelated docs work: `Image.blobs()` had no generated docs page before a separate fix restored it, so its live doctest example had never actually executed during a docs build, and this crash went unnoticed.

## Test plan
- [x] `pytest tests/` — 816 passed, 0 failed, 15 skipped (pre-existing skips)
- [x] Reproduced the crash directly against `main` before the fix, confirmed it's gone after