### PR TITLE
ci: add an all-tests-passed aggregator job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,19 @@ jobs:
           MPLBACKEND: Agg
         run: micromamba run -n myenv python -m pytest --timeout=50 --timeout-method=thread
 
+  all-tests-passed:
+    name: All tests passed
+    needs: test
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test matrix result
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test matrix did not succeed: ${{ needs.test.result }}"
+            exit 1
+          fi
+
   codecov:
     needs: test
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Adds a single `All tests passed` job that depends on the full `test` matrix (12 legs: 3 OS × 4 Python versions) and fails loudly if any leg didn't succeed.
- Purpose: give branch protection one stable check name to require, instead of requiring all 12 individual matrix-leg names directly (brittle — silently stops enforcing anything if the matrix ever changes without a manual settings update).
- No other behavior change; existing `test` and `codecov` jobs untouched.

## Test plan
- [x] YAML validated
- [x] This PR's own CI run exercises the new job directly — should show `All tests passed` in the checks list below