### PR TITLE
fix: gridify() IndexError from numpy float // int staying float64

### DIFF
--- a/src/machinevisiontoolbox/ImagePointFeatures.py
+++ b/src/machinevisiontoolbox/ImagePointFeatures.py
@@ -294,8 +294,8 @@ class BaseFeature2D:
         bins = np.zeros((nh, nw), dtype="int")
 
         for f in self:
-            ix = f.p[0] // binwidth
-            iy = f.p[1] // binheight
+            ix = int(f.p[0].item() // binwidth)
+            iy = int(f.p[1].item() // binheight)
 
             if bins[iy, ix] < nfeat:
                 keep.append(f)

--- a/tests/test_image_point_features.py
+++ b/tests/test_image_point_features.py
@@ -190,6 +190,26 @@ class TestImagePointFeatures(unittest.TestCase):
         except:
             pass
 
+    def test_gridify_scalar_nbins(self):
+        """gridify() with a scalar nbins must not raise (regression: numpy
+        float // int stayed float64, bins[iy, ix] then rejected as an index)"""
+        img = Image.Read("monalisa.png", mono=True)
+        sift = img.SIFT()
+        self.assertGreater(len(sift), 0)
+
+        gridded = sift.gridify(nbins=4, nfeat=2)
+        self.assertLessEqual(len(gridded), len(sift))
+
+    def test_gridify_tuple_nbins(self):
+        """gridify() with a (nw, nh) tuple must not raise, same root cause
+        as the scalar case above."""
+        img = Image.Read("monalisa.png", mono=True)
+        sift = img.SIFT()
+        self.assertGreater(len(sift), 0)
+
+        gridded = sift.gridify(nbins=(4, 3), nfeat=2)
+        self.assertLessEqual(len(gridded), len(sift))
+
     def test_feature_properties(self):
         """Test feature properties"""
         img = Image.Read("monalisa.png", mono=True)


### PR DESCRIPTION
## Summary
- `BaseFeature2D.gridify()` crashed with `IndexError: arrays used as indices must be of integer (or boolean) type` on **every** call, regardless of whether `nbins` was passed as a tuple or scalar.
- Root cause: `f.p[0] // binwidth` / `f.p[1] // binheight` — `f.p` is a numpy float array (shape `(2,1)`), and floor-dividing a numpy float array by a Python int still yields a `float64` result, not an int. `bins[iy, ix]` then rejects the float-typed index.
- Fix: `int(f.p[0].item() // binwidth)` — extract the scalar with `.item()` first, then cast.
- `gridify()` had zero test coverage before this. Added two regression tests (scalar and tuple `nbins`). Verified genuinely: reverted just the source fix (kept the test), confirmed both tests fail with the exact reported `IndexError`, then restored the fix and confirmed they pass.
- Found while verifying an unrelated bare-except cleanup on a different branch — this crash reproduced identically on unmodified `main` (confirmed via `git stash`), so it's pre-existing, not something that fix introduced.

## Test plan
- [x] New tests fail on unfixed code with the exact reported error, pass with the fix (verified both directions)
- [x] Full suite: 818 passed (816 + 2 new), 15 skipped, no other regressions