### PR TITLE
fix: replace 6 bare except: clauses with specific exception types

### DIFF
--- a/src/machinevisiontoolbox/BundleAdjust.py
+++ b/src/machinevisiontoolbox/BundleAdjust.py
@@ -12,7 +12,7 @@ try:
     import pgraph
 
     pgraph_installed = True
-except:
+except ImportError:
     print("pgraph not installed")
     pgraph_installed = False
 import matplotlib.pyplot as plt

--- a/src/machinevisiontoolbox/Camera.py
+++ b/src/machinevisiontoolbox/Camera.py
@@ -827,7 +827,7 @@ class CameraBase(ABC):
             for artist in self._ax.get_children():
                 try:
                     artist.remove()
-                except:
+                except Exception:
                     pass
 
     def plot_point(
@@ -1862,7 +1862,7 @@ class CentralCamera(CameraBase):
         """
         try:
             return 2 * np.arctan(np.r_[self.imagesize] / 2 * np.r_[self.rho] / self.f)
-        except:
+        except (TypeError, AttributeError):
             raise ValueError("imagesize or rho properties not set")
 
     def distort(self, points: np.ndarray) -> np.ndarray:

--- a/src/machinevisiontoolbox/ImagePointFeatures.py
+++ b/src/machinevisiontoolbox/ImagePointFeatures.py
@@ -280,7 +280,7 @@ class BaseFeature2D:
 
         try:  # Sort features into grid
             nw, nh = nbins
-        except:
+        except (TypeError, ValueError):
             nw = nbins
             nh = nbins
 

--- a/src/machinevisiontoolbox/ImageProcessing.py
+++ b/src/machinevisiontoolbox/ImageProcessing.py
@@ -1146,7 +1146,7 @@ class ImageProcessingMixin(_ImageBase if TYPE_CHECKING else object):
                 else:
                     try:
                         color = argcheck.getvector(image2, 3)
-                    except:
+                    except Exception:
                         raise ValueError("expecting a scalar, string or 3-vector")
                 if self.isbgr:
                     color = color[::-1]

--- a/src/machinevisiontoolbox/__init__.py
+++ b/src/machinevisiontoolbox/__init__.py
@@ -188,5 +188,5 @@ try:
     import importlib.metadata
 
     __version__ = importlib.metadata.version("machinevision-toolbox-python")
-except:
+except importlib.metadata.PackageNotFoundError:
     pass

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -1,5 +1,31 @@
 # Technical Debt
 
+## `BaseFeature2D.gridify()` crashes with IndexError, always
+
+Found 2026-07-29 while verifying the narrowed exception type on
+`ImagePointFeatures.py:283`'s `nw, nh = nbins` unpack (part of a bare
+`except:` cleanup). `gridify()` (`ImagePointFeatures.py:261-301`)
+raises `IndexError: arrays used as indices must be of integer (or
+boolean) type` on every call, regardless of whether `nbins` is passed
+as a tuple or a scalar int — confirmed via `git stash` that this is
+identical on unmodified `main`, unrelated to the except-type change
+that surfaced it.
+
+Root cause: `ix = f.p[0] // binwidth` / `iy = f.p[1] // binheight`
+(lines 294-295) — `f.p` is a numpy float array (feature point
+coordinates), and floor-dividing a numpy float array by a Python int
+still yields a numpy `float64` result, not an int. `bins[iy, ix]`
+(line 300) then fails because numpy refuses float-dtype indices.
+
+### Fix
+
+Cast to int after the floor division, e.g.
+`ix = int(f.p[0] // binwidth)` / `iy = int(f.p[1] // binheight)`. Small,
+self-contained, real bug fix — bundle with its own `fix:` commit and a
+regression test (`gridify()` currently has no test coverage at all;
+none of the existing point-feature tests exercise it) rather than
+folding into an unrelated change.
+
 ## `Image.ncdf` is documented as deprecated but never warns
 
 `ncdf` (`src/machinevisiontoolbox/ImageWholeFeatures.py:511-523`) has a


### PR DESCRIPTION
## Summary
Bare `except:` swallows everything including `KeyboardInterrupt`/`SystemExit` and hides the real failure mode. Narrowed all 6 in the codebase (confirmed via fresh grep — no more remain) to what the guarded code can actually raise:

| Location | Guards | Narrowed to |
|---|---|---|
| `BundleAdjust.py:15` | `import pgraph` fallback | `ImportError` |
| `ImagePointFeatures.py:283` | `nw, nh = nbins` unpack (scalar `nbins` is a valid fallback path) | `TypeError, ValueError` |
| `Camera.py:830` | `artist.remove()` in `clf()`, arbitrary matplotlib `Artist` | `Exception` |
| `Camera.py:1865` | arithmetic on possibly-unset `imagesize`/`rho` in `fov()` | `TypeError, AttributeError` |
| `ImageProcessing.py:1149` | `argcheck.getvector(image2, 3)` | `Exception` |
| `__init__.py:191` | `importlib.metadata.version()` lookup | `importlib.metadata.PackageNotFoundError` |

Also logs a real bug found while verifying this (`gridify()`'s `nw, nh = nbins` path) to `tech-debt.md` — since fixed and merged separately in #30, not bundled here.

## Test plan
- [x] `grep -rn "except:" src/machinevisiontoolbox/*.py` — zero matches
- [x] Manually exercised the narrowed paths: `fov()` called before `imagesize`/`rho` set still raises the intended `ValueError`; `choose()` with an invalid `image2` still raises the intended `ValueError`
- [x] Full suite: 816 passed, 15 skipped, no regressions