### PR TITLE
fix: add missing type annotations, warn on ncdf deprecation

### DIFF
--- a/src/machinevisiontoolbox/ImageRegionFeatures.py
+++ b/src/machinevisiontoolbox/ImageRegionFeatures.py
@@ -242,7 +242,7 @@ class MSERFeature:
 
         return new
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         String representation of MSER
 
@@ -265,7 +265,7 @@ class MSERFeature:
             s = f"MSER feature: u: {self._bboxes[0,0]} - {self._bboxes[0,2]}, v: {self._bboxes[0,1]} - {self._bboxes[0,3]}"
             return s
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """
         Representation of MSER
 
@@ -373,7 +373,7 @@ class OCRWord:
         for key in ocr.keys():
             self.dict[key] = ocr[key][i]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         String representation of MSER
 
@@ -382,7 +382,7 @@ class OCRWord:
         """
         return f"{self.dict['text']} ({self.dict['conf']}%)"
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self)
 
     @property

--- a/src/machinevisiontoolbox/ImageWholeFeatures.py
+++ b/src/machinevisiontoolbox/ImageWholeFeatures.py
@@ -11,6 +11,7 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy as sp
+from matplotlib.axes import Axes
 from matplotlib.patches import Polygon
 from matplotlib.ticker import ScalarFormatter
 from spatialmath import SE3, base
@@ -519,6 +520,11 @@ class ImageWholeFeaturesMixin(_ImageBase if TYPE_CHECKING else object):
         .. deprecated:: 2.0.0
             Use ``hist().cdf`` instead.
         """
+        warnings.warn(
+            "Deprecated in 2.0.0: use hist().cdf instead of ncdf.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         hist = self._default_hist()
         return hist.cdf
 
@@ -1193,26 +1199,31 @@ class Histogram:
         :rtype: ndarray(N) or ndarray(N,P)
 
         .. deprecated:: 2.0.0
-            Use ``hist().cdf`` instead.
+            Use ``cdf`` instead.
         """
+        warnings.warn(
+            "Deprecated in 2.0.0: use .cdf instead of .ncdf.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.cdf
 
     def plot(
         self,
-        type="frequency",
-        block=False,
-        filled=None,
-        stats=True,
-        style="stack",
-        cursor=False,
-        alpha=0.5,
-        title=None,
-        log=False,
-        samescale=False,
-        ax=None,
-        bar=None,
-        **kwargs,
-    ):
+        type: str = "frequency",
+        block: bool = False,
+        filled: bool | None = None,
+        stats: bool = True,
+        style: str = "stack",
+        cursor: bool = False,
+        alpha: float = 0.5,
+        title: str | None = None,
+        log: bool = False,
+        samescale: bool = False,
+        ax: Axes | None = None,
+        bar: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         """
         Plot histogram
 

--- a/src/machinevisiontoolbox/Sources.py
+++ b/src/machinevisiontoolbox/Sources.py
@@ -3113,7 +3113,7 @@ class ROSBag(ImageSource):
             reader.close()
             self.reader = None
 
-    def _open_reader(self):
+    def _open_reader(self) -> Any:
         if self.reader is not None:
             return self.reader
 

--- a/tech-debt.md
+++ b/tech-debt.md
@@ -1,5 +1,26 @@
 # Technical Debt
 
+## `Histogram.plot`'s `type` docstring doesn't match its actual accepted values
+
+Found 2026-07-30 while adding type annotations to `Histogram.plot`
+(`ImageWholeFeatures.py:1200`). The docstring says `type` accepts
+`'frequency'` [default], `'cdf'`, or `'ncdf'`. The actual dispatch logic
+in the method body accepts a different, larger set:
+`'frequency'`, `'pdf'`/`'probability'`, `'cf'`/`'cumulative'`,
+`'cdf'`/`'normalized'` — and does **not** handle `'ncdf'` at all (it
+would fall through to the `else: raise ValueError("unknown type")`
+branch). Left `type` annotated as plain `str` rather than a `Literal`
+enum for this reason — using `Literal` would mean either copying the
+stale docstring's wrong values or silently fixing behavior/docs as a
+drive-by, both out of scope for an annotations-only pass.
+
+### Fix
+
+Reconcile the docstring with the real accepted values (or vice versa,
+if `'ncdf'` was meant to work and was dropped by accident — check git
+blame). Once settled, `type` can become
+`Literal["frequency", "pdf", "probability", "cf", "cumulative", "cdf", "normalized"]`.
+
 ## [HIGH PRIORITY] mypy is not run anywhere in CI or dev tooling
 
 Found 2026-07-29 while fixing the `_ImageBase` Protocol gaps in

--- a/tests/test_image_whole_features.py
+++ b/tests/test_image_whole_features.py
@@ -463,12 +463,22 @@ class TestImageWholeFeatures(unittest.TestCase):
 
     # new test
     def test_ncdf_property(self):
-        """Test normalized CDF property"""
+        """Test normalized CDF property, and that it warns as deprecated"""
         im = Image.Random(size=(50, 50), dtype="uint8")
-        ncdf = im.ncdf
+        with self.assertWarns(DeprecationWarning):
+            ncdf = im.ncdf
         self.assertIsNotNone(ncdf)
         # Normalized CDF should end at 1.0
         # self.assertAlmostEqual(ncdf[-1], 1.0)
+
+    def test_histogram_ncdf_deprecated(self):
+        """Histogram.ncdf (as opposed to Image.ncdf above) should also warn,
+        and should still return the same values as Histogram.cdf"""
+        im = Image.Random(size=(50, 50), dtype="uint8")
+        h = im.hist()
+        with self.assertWarns(DeprecationWarning):
+            ncdf = h.ncdf
+        nt.assert_array_equal(ncdf, h.cdf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

**Type annotations (finding 6)**
- `Histogram.plot()`: full signature was completely unannotated. Added types to every parameter and the return type. Kept the `type=` parameter name as-is despite shadowing the builtin — it's public API (`hist.plot(type="pdf")`), renaming is a breaking change out of scope here. Left it typed as plain `str` rather than `Literal` — its docstring's listed values don't match what the method actually accepts (logged as its own `tech-debt.md` entry, found while doing this).
- `ImageRegionFeatures.py`: both `__str__`/`__repr__` pairs → `str`
- `Sources.py`: `_open_reader()` → `Any` (conditionally-imported ROS reader type behind an optional dependency, matching the existing pattern used elsewhere in the file)

**Deprecation warnings (finding 7, corrected from the original review)** — the original review's `ImageCore.py` `A`-property version-drift claim didn't reproduce (both sides already say `2.0.0`). The real gap: `ImageWholeFeaturesMixin.ncdf` (`Image.ncdf`) and `Histogram.ncdf` both had a `.. deprecated:: 2.0.0` docstring note but neither ever called `warnings.warn`, unlike every other deprecated method in the codebase. Added the standard warning to both, with messages matching what each actually delegates to — also fixed `Histogram.ncdf`'s docstring, which incorrectly said "use `hist().cdf`" despite `self` already being the `Histogram` instance.

## Test plan
- [x] Added a regression test for the new `Histogram.ncdf` warning, updated the existing `Image.ncdf` test to also assert the warning
- [x] Verified genuinely: reverted just the two `warnings.warn` calls (source only, kept tests), confirmed both fail with "DeprecationWarning not triggered", restored the fix, confirmed both pass
- [x] Full suite: 817 passed (816 + 1 net new test), 15 skipped, no regressions