### PR TITLE
fix: keep single-blob filter() matches

### DIFF
--- a/src/machinevisiontoolbox/ImageBlobs.py
+++ b/src/machinevisiontoolbox/ImageBlobs.py
@@ -637,7 +637,7 @@ class Blobs(UserList):  # lgtm[py/missing-equals]
             return self[:]
         m: np.ndarray = np.array(mask).all(axis=0)  # type: ignore[assignment]
 
-        return self[m]
+        return self[m.flatten()]
 
     def sort(self, by: str = "area", reverse: bool = False) -> "Blobs":  # type: ignore[override]
         """

--- a/tests/test_image_blobs.py
+++ b/tests/test_image_blobs.py
@@ -522,6 +522,19 @@ class TestBlobMethods(unittest.TestCase):
         removed = self.blobs4.filter(touch=True)
         self.assertEqual(len(removed), 0)
 
+    def test_filter_area_single_blob_keeps_match(self):
+        # Regression for GH issue #17: a single-blob Blobs mask came out
+        # 2D (from np.array(mask).all(axis=0)) and indexing self[m] with
+        # it dropped the blob even though it matched the filter.
+        area = self.blobs1[0].area
+        kept = self.blobs1.filter(area=area * 0.5)
+        self.assertEqual(len(kept), 1)
+
+    def test_filter_area_single_blob_removes_non_match(self):
+        area = self.blobs1[0].area
+        removed = self.blobs1.filter(area=area * 2)
+        self.assertEqual(len(removed), 0)
+
     # --- sort --------------------------------------------------------------- #
 
     def test_sort_returns_blobs(self):


### PR DESCRIPTION
## Summary
- `Blobs.filter()` built its mask via `np.array(mask).all(axis=0)`, which stays 2D when there's only one blob in the set. Indexing `self[m]` with a 2D boolean array silently dropped the blob even when it matched the filter criteria.
- Fix: flatten the mask before indexing (`self[m.flatten()]`).

Fixes #17

## Test plan
- [x] Added regression tests using the existing single-blob fixture (`blobs1`): one asserting a matching blob is kept, one asserting a non-matching blob is removed.
- [x] Verified the new keep-test fails without the fix (`0 != 1`) and passes with it.
- [x] Full `tests/test_image_blobs.py`: 99 passed, 3 skipped, no regressions.