### PR TITLE
ci: auto-merge patch/minor Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor bumps
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Dependabot PRs (#19-23) sat unattended for over a month, each accumulating enough drift from `main` that merging required a full manual rebase + CI retry cycle.
- Adds the standard GitHub-documented auto-merge recipe: `dependabot/fetch-metadata` reads the update type, and patch/minor bumps get `gh pr merge --auto --merge` enabled as soon as their own CI is green. Major bumps are intentionally excluded -- still require manual review (matches how #19/#21, both major version jumps, were handled this session).
- Uses `--merge` (not `--squash`) to match this repo's existing merge-commit convention.
- Relies on the repo's `allow_auto_merge` setting (enabled) and the branch-protection required check already narrowed to just `All tests passed` -- auto-merge still can't complete until that passes, so nothing merges without real CI signal.

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] First real signal will be the next scheduled Dependabot run (monthly, per `dependabot.yml`) -- can't fully dry-run this without a live Dependabot-authored PR.