### PR TITLE
fix: add socket timeout to iread() URL fetches

### DIFF
--- a/src/machinevisiontoolbox/base/imageio.py
+++ b/src/machinevisiontoolbox/base/imageio.py
@@ -1041,7 +1041,7 @@ def iread(
             headers={"User-Agent": "machinevisiontoolbox-python/1.0"},
         )
         try:
-            with urllib.request.urlopen(req, context=ctx) as resp:
+            with urllib.request.urlopen(req, context=ctx, timeout=10) as resp:
                 if resp.status != 200:
                     raise ValueError(f"HTTP {resp.status} fetching {filename}")
                 array = np.asarray(bytearray(resp.read()), dtype="uint8")


### PR DESCRIPTION
## Summary
- `iread()`'s URL-fetch path called `urllib.request.urlopen(req, context=ctx)` with no `timeout=` -- a stalled SSL handshake against a slow/unresponsive server hung indefinitely. This was hit repeatedly this session as CI flakiness: `tests/base/test_io.py`'s `test_iread`/`test_iread_url_handling` fetch a real image from `petercorke.com`, and an occasional stalled handshake let pytest's own blunt `--timeout=50` thread-kill fire first, surfacing as a hard failure instead of the graceful `except URLError: SkipTest` the tests were already written to hit.
- Also a real production bug, not just test flakiness -- any caller of `iread()` on a slow URL hangs forever the same way.
- Fix: add `timeout=10` to the `urlopen()` call. Verified empirically that a stalled connection raises `URLError` wrapping `TimeoutError` (not some other exception type), which both `iread()`'s existing except clause and the tests' `SkipTest` path already handle correctly -- no other code changes needed.

## Test plan
- [x] Verified the exception type empirically: a connection to a non-routable address raises `urllib.error.URLError` wrapping `TimeoutError`, confirming the existing except clause catches it.
- [x] `tests/base/test_io.py` in isolation: 125 passed in 3.7s (real network fetch succeeded well within the new budget).
- [x] Full suite: 771 passed, 94 skipped, no regressions.