### PR TITLE
docs: add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report unexpected behavior or a crash
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: MVTB version
+      description: Output of `pip show machinevision-toolbox-python`
+      placeholder: "e.g. 1.2.3"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.12.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options: [Linux, macOS, Windows, Other]
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproducible example
+      description: A short, self-contained code snippet that reproduces the issue
+      render: python
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/petercorke/machinevision-toolbox-python/discussions
+    about: For general questions, ideas, and discussion — not a good fit for the two forms above.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,11 +13,22 @@ body:
     id: proposal
     attributes:
       label: Proposed solution
+      description: >-
+        What would the MVTB function/method look like? Include its
+        signature — parameter names and types, and the return
+        value(s) and type(s).
+      placeholder: |
+        def new_method(self, threshold: float, mode: Literal["a", "b"] = "a") -> NDArray:
+            ...
     validations:
       required: false
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives considered
+      description: >-
+        Any existing MVTB function that's close, a workaround you're
+        currently using, or another API shape you considered and why
+        it didn't fit. Leave blank if none.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -30,5 +30,8 @@ body:
         Any existing MVTB function that's close, a workaround you're
         currently using, or another API shape you considered and why
         it didn't fit. Leave blank if none.
+      placeholder: |
+        e.g. "Currently chaining img.threshold(...) then manual masking —
+        works but takes 3 extra steps and doesn't handle the RGBA case."
     validations:
       required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,9 +4,16 @@ Thanks for contributing to MVTB!
 
 <!-- What does this PR do, and why? -->
 
-## Test plan
+## Related issue
 
+<!-- Fixes #123 / Closes #123 — if applicable -->
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`type: description`) — checked automatically, see the "Check PR title" status
 - [ ] Tests pass locally (`pytest`)
 - [ ] Added/updated tests for this change, if applicable
+- [ ] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
+- [ ] Docstrings updated (reST style: `:param:`, `:type:`, `:returns:`, `:rtype:`)
 
 <!-- Target branch is `main` — release-please handles versioning automatically. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+Thanks for contributing to MVTB!
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Test plan
+
+- [ ] Tests pass locally (`pytest`)
+- [ ] Added/updated tests for this change, if applicable
+
+<!-- Target branch is `main` — release-please handles versioning automatically. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@ Thanks for contributing to MVTB!
 - [ ] Tests pass locally (`pytest`)
 - [ ] Added/updated tests for this change, if applicable
 - [ ] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
-- [ ] Docstrings updated (reST style: `:param:`, `:type:`, `:returns:`, `:rtype:`)
+- [ ] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
 
-<!-- Target branch is `main` — release-please handles versioning automatically. -->
+<!-- Target branch is `main` — release-please handles versioning automatically.
+
+Note: Codacy will automatically comment on this PR with style/coverage findings.
+Most of what it flags is pre-existing backlog (see tech-debt.md), not something
+your PR introduced -- don't be alarmed by the summary, a maintainer will triage it. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,15 +16,7 @@ Thanks for contributing to MVTB!
 - [ ] New/changed code is type-hinted with modern syntax (`X | Y`, `list[X]`, not `Union`/`Optional`/`List`)
 - [ ] Docstrings updated (reST style: `:param:`, `:returns:`; type hints in the signature cover types now, `:type:`/`:rtype:` are rarely needed)
 
-<!-- Target branch is `main` — release-please handles versioning automatically.
+> **Automated bot comments to expect:** Codacy will comment with style/coverage findings — most of it is pre-existing backlog (see `tech-debt.md`), not something your PR introduced, so don't be alarmed. If this PR adds or bumps a dependency, Dependabot may separately comment flagging a known vulnerability — if so, use a newer patched version if one exists, or just note it in this PR and a maintainer will decide; you don't need to solve it yourself.
 
-Note: Codacy will automatically comment on this PR with style/coverage findings.
-Most of what it flags is pre-existing backlog (see tech-debt.md), not something
-your PR introduced -- don't be alarmed by the summary, a maintainer will triage it.
-
-Note: if this PR adds or bumps a dependency, Dependabot may separately comment
-flagging a known vulnerability in that dependency. If it does: check whether a
-newer, patched version is available and use that instead; if not, just say so
-in this PR so a maintainer can decide how to proceed -- it's not something you
-need to solve yourself. -->
+<!-- Target branch is `main` — release-please handles versioning automatically. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,11 @@ Thanks for contributing to MVTB!
 
 Note: Codacy will automatically comment on this PR with style/coverage findings.
 Most of what it flags is pre-existing backlog (see tech-debt.md), not something
-your PR introduced -- don't be alarmed by the summary, a maintainer will triage it. -->
+your PR introduced -- don't be alarmed by the summary, a maintainer will triage it.
+
+Note: if this PR adds or bumps a dependency, Dependabot may separately comment
+flagging a known vulnerability in that dependency. If it does: check whether a
+newer, patched version is available and use that instead; if not, just say so
+in this PR so a maintainer can decide how to proceed -- it's not something you
+need to solve yourself. -->
+


### PR DESCRIPTION
## Summary
- MVTB had no PR or issue templates at all (confirmed via community-profile API and repo search).
- Adds `.github/pull_request_template.md`: short thanks-for-contributing line, `## Summary`/`## Test plan` checklist, no stale branch-workflow instructions (unlike RTB's existing template, which still references a `future` branch that no longer exists there).
- Adds two GitHub issue forms (not old-style freeform markdown): `bug_report.yml` (version, Python version, OS, expected/actual behavior, minimal repro -- all required) and `feature_request.yml` (only the problem statement required, proposal/alternatives optional).
- Adds `config.yml`: disables blank issues now that Discussions is enabled on this repo, routing general questions there instead of into an ill-fitting bug/feature form.
- This is the guinea pig for the same rollout across RTB/bdsim/spatialgeometry (swift once its own default-branch migration lands separately) -- see the `toolbox-maintainer` skill for the full cross-repo policy. SMTB is excluded (now effectively governed by RAI-Inst).

## Test plan
- [x] All three YAML files validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
- [ ] Live-render preview: paste each form's content into `github.com/petercorke/machinevision-toolbox-python/issues/templates/edit` to see it rendered before merging.