### PR TITLE
docs: use %pip magic in notebooks, add tagline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <div align="center">
   <img src="https://github.com/petercorke/machinevision-toolbox-python/raw/main/docs/figs/VisionToolboxLogo_NoBackgnd@2x.png" width="350">
   <br>
+    <em>OpenCV for humans</em><br>
   <strong>A high-productivity framework for computer vision research and education.</strong>
   <br><br>
   

--- a/docs/notebooks/IBVS.ipynb
+++ b/docs/notebooks/IBVS.ipynb
@@ -38,7 +38,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/calibration.ipynb
+++ b/docs/notebooks/calibration.ipynb
@@ -25,7 +25,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/camera.ipynb
+++ b/docs/notebooks/camera.ipynb
@@ -40,7 +40,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/color-images.ipynb
+++ b/docs/notebooks/color-images.ipynb
@@ -34,7 +34,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/fiducials.ipynb
+++ b/docs/notebooks/fiducials.ipynb
@@ -40,7 +40,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/finding-blobs.ipynb
+++ b/docs/notebooks/finding-blobs.ipynb
@@ -40,7 +40,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print(\"Running on CoLab\")\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/gamma.ipynb
+++ b/docs/notebooks/gamma.ipynb
@@ -34,7 +34,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/greyscale-images.ipynb
+++ b/docs/notebooks/greyscale-images.ipynb
@@ -34,7 +34,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/homography.ipynb
+++ b/docs/notebooks/homography.ipynb
@@ -40,7 +40,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/image-convolution.ipynb
+++ b/docs/notebooks/image-convolution.ipynb
@@ -34,7 +34,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/image-features.ipynb
+++ b/docs/notebooks/image-features.ipynb
@@ -40,7 +40,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/image-motion.ipynb
+++ b/docs/notebooks/image-motion.ipynb
@@ -38,7 +38,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",

--- a/docs/notebooks/image-processing.ipynb
+++ b/docs/notebooks/image-processing.ipynb
@@ -34,7 +34,7 @@
     "try:\n",
     "    import google.colab\n",
     "    print('Running on CoLab')\n",
-    "    !pip install machinevision-toolbox-python\n",
+    "    %pip install machinevision-toolbox-python\n",
     "    COLAB = True\n",
     "except:\n",
     "    COLAB = False\n",


### PR DESCRIPTION
## Summary
- Replace `!pip install machinevision-toolbox-python` with `%pip install machinevision-toolbox-python` across all 13 notebooks in `docs/notebooks/` -- `%pip` is the magic-command form that installs into the actual running kernel's environment, where `!pip` shells out and can silently target a different Python than the notebook is using (particularly relevant for JupyterLite/Pyodide, where a bare `!pip` doesn't work at all).
- Add an `<em>OpenCV for humans</em>` tagline under the logo in `README.md`.

Both were sitting uncommitted on the stalled `opencv5` branch, unrelated to that branch's actual (incomplete) OpenCV 5 compatibility work -- pulled out and landed independently so they aren't lost when that branch is retired.

## Test plan
- [ ] N/A -- docs-only change, no code touched