### PR TITLE
ci: normalize to actions/setup-python + pip, matching sibling toolboxes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,44 +19,23 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: actions/setup-python@v6
         with:
-          init-shell: >-
-            bash
-            powershell
-          environment-name: myenv
-          create-args: >-
-            python=${{ matrix.python-version }}
-            numpy
-            pip
-            pytest
-            pytest-timeout
-            pytest-xvfb
-            matplotlib-base
-            setuptools
-            opencv<5
-            scipy
-            spatialmath-python
-            ansitable
-            wcwidth
-            tqdm
-            hatchling
-            ipython
-            pygments
+          python-version: ${{ matrix.python-version }}
 
       - name: Install libegl (Linux)
         if: runner.os == 'Linux'
-        run: micromamba install -y -n myenv -c conda-forge libegl
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1
 
       - name: Install package
         run: |
-          micromamba run -n myenv pip install .[dev] --no-deps --no-build-isolation
-          cd packages/mvtb-data && micromamba run -n myenv pip install . --no-deps --no-build-isolation
+          pip install .[dev,tool]
+          cd packages/mvtb-data && pip install .
 
       - name: Run tests
         env:
           MPLBACKEND: Agg
-        run: micromamba run -n myenv python -m pytest --timeout=50 --timeout-method=thread
+        run: python -m pytest --timeout=50 --timeout-method=thread
 
   all-tests-passed:
     name: All tests passed
@@ -79,44 +58,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: mamba-org/setup-micromamba@v2
+      - uses: actions/setup-python@v6
         with:
-          init-shell: bash
-          environment-name: myenv
-          create-args: >-
-            python=3.13
-            numpy
-            pip
-            coverage
-            pytest
-            pytest-timeout
-            pytest-xvfb
-            matplotlib-base
-            setuptools
-            opencv<5
-            scipy
-            spatialmath-python
-            ansitable
-            wcwidth
-            tqdm
-            hatchling
-            ipython
-            pygments
+          python-version: "3.13"
 
       - name: Install libegl
-        run: micromamba install -y -n myenv -c conda-forge libegl
+        run: sudo apt-get update && sudo apt-get install -y libegl1 libgl1
 
       - name: Install package
         run: |
-          micromamba run -n myenv pip install .[dev] --no-deps --no-build-isolation
-          cd packages/mvtb-data && micromamba run -n myenv pip install . --no-deps --no-build-isolation
+          pip install .[dev,tool]
+          cd packages/mvtb-data && pip install .
 
       - name: Run coverage
         env:
           MPLBACKEND: Agg
         run: |
-          micromamba run -n myenv coverage run --source=machinevisiontoolbox --omit="src/machinevisiontoolbox/blocks/*,src/machinevision/blocks/*" -m pytest --timeout=50
-          micromamba run -n myenv coverage xml
+          coverage run --source=machinevisiontoolbox --omit="src/machinevisiontoolbox/blocks/*,src/machinevision/blocks/*" -m pytest --timeout=50
+          coverage xml
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
 #  ocr - OCR support via pytesseract
 #  tool - dependencies for the mvtbtool interactive shell
 
-dev = ["pytest", "coverage", "ruff", "nbmake"]
+dev = ["pytest", "pytest-timeout", "pytest-xvfb", "coverage", "ruff", "nbmake"]
 
 ros = ["rosbags", "roslibpy", "websockets"]
 


### PR DESCRIPTION
## Summary
- Replace `mamba-org/setup-micromamba` + hand-maintained conda `create-args` with `actions/setup-python` + plain `pip install .[dev,tool]`, matching RTB/bdsim/SMTB's CI setup -- MVTB was the only sibling toolbox still on conda.
- Drop `--no-deps --no-build-isolation`: previously CI's pip install explicitly skipped dependency resolution, so `pyproject.toml`'s `opencv-python<5.0.0` / `opencv-contrib-python<5.0.0` pins were never actually enforced by CI -- only by real end users installing via `pip`. That gap is exactly how CI silently started testing OpenCV 5.0.0 once conda-forge's unpinned `opencv` package resolved there (see #44).
- Add `pytest-timeout`/`pytest-xvfb` to the `dev` extra in `pyproject.toml` (previously only present in the conda `create-args` list, so `pip install .[dev]` alone was missing what the test run actually needs).
- Swap the Linux-only conda-forge `libegl` install for the apt equivalent (`libegl1 libgl1`).

Fixes #43

## Test plan
- [x] Installed into a real, verified-isolated throwaway venv (`sys.prefix` checked) with plain `pip install .[dev,tool]` -- resolves cleanly, honoring the `<5.0.0` opencv pin for real (`opencv-contrib-python-4.14.0.94`).
- [x] Full test suite passes under that install: 771 passed, 94 skipped, no failures.
- [ ] CI itself (this PR's own run) -- watching now.