### PR TITLE
docs: fix stale/broken references and add footer build date

### DIFF
--- a/docs/source/card-algorithms.rst
+++ b/docs/source/card-algorithms.rst
@@ -69,7 +69,7 @@ by the toolbox.  Consider these as some starting points for exploration.
       - Camera calibration: :meth:`~machinevisiontoolbox.Camera.CentralCamera.images2C`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.decomposeC`
       - Pose estimation: :meth:`machinevisiontoolbox.Camera.CentralCamera.estpose`
       - Projection: :meth:`~machinevisiontoolbox.Camera.CentralCamera.project_point`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.project_line`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.project_conic`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.project_quadric`
-      - Epipolar geometry: :meth:`~machinevisiontoolbox.Camera.CentralCamera.E`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.F`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.epiline`, CentralCamera.decomposeF, :meth:`~machinevisiontoolbox.Camera.CentralCamera.decomposeE`
+      - Epipolar geometry: :meth:`~machinevisiontoolbox.Camera.CentralCamera.E`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.F`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.epiline`, :meth:`~machinevisiontoolbox.Camera.CentralCamera.decomposeE`
       - Homography: :meth:`~machinevisiontoolbox.Camera.CentralCamera.H`
    - Fisheye camera: :class:`~machinevisiontoolbox.Camera.FishEyeCamera`
    - Catadioptric (omnidirectional) camera: :class:`~machinevisiontoolbox.Camera.CatadioptricCamera`

--- a/docs/source/card-algorithms.rst
+++ b/docs/source/card-algorithms.rst
@@ -21,7 +21,7 @@ by the toolbox.  Consider these as some starting points for exploration.
 
    * Mathematical morphology: :meth:`~machinevisiontoolbox.Image.morph`, :meth:`~machinevisiontoolbox.Image.open`, :meth:`~machinevisiontoolbox.Image.close`, :meth:`~machinevisiontoolbox.Image.dilate`, :meth:`~machinevisiontoolbox.Image.erode`
    * Hit or Miss filtering: :meth:`~machinevisiontoolbox.Image.hitormiss`, :meth:`~machinevisiontoolbox.Image.thin`, :meth:`~machinevisiontoolbox.Image.triplepoint`
-   * Rank filter: :meth:`~machinevisiontoolbox.Image.rank`, :meth:`~machinevisiontoolbox.Image.medianfilter`
+   * Rank filter: :meth:`~machinevisiontoolbox.Image.rankfilter`, :meth:`~machinevisiontoolbox.Image.medianfilter`
    * Distance transform: :meth:`~machinevisiontoolbox.Image.distance_transform`
    * Image similarity: :meth:`~machinevisiontoolbox.Image.similarity`
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,6 +10,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 import inspect
@@ -28,7 +29,7 @@ if _EXTS_DIR not in sys.path:
 # -- Project information -----------------------------------------------------
 
 project = "Machine Vision Toolbox"
-copyright = "2020-, Peter Corke"
+copyright = f"2020–present, Peter Corke: built {datetime.date.today():%Y-%m-%d}"
 author = "Peter Corke"
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
## Summary
- \`rank()\` was deprecated in favour of \`rankfilter()\`, but the "Rank filter" entry on the algorithms overview page (https://petercorke.github.io/machinevision-toolbox-python/card-algorithms.html) still pointed at the old name. Checked every other deprecated method/property name (21 total, cross-referenced against every \`DeprecationWarning\` call in the codebase) against every \`.rst\` file in \`docs/source/\` -- this was the only stale reference found anywhere.
- Removed a mention of \`CentralCamera.decomposeF\`, which doesn't exist anywhere in the codebase and can't meaningfully exist: a fundamental matrix alone can't be decomposed into a relative pose without the camera intrinsics -- that's exactly what \`decomposeE\` already handles via the standard F -> E (using K) -> pose route. It was left as plain text rather than a \`:meth:\` cross-reference (presumably to avoid a broken-link build warning), the only trace of it in the repo.
- Added the Sphinx build date to the footer copyright notice on every page, computed dynamically at build time so it always reflects when the docs were actually built. Also cleaned up the year range from the ambiguous trailing "2020-," to "2020-present," while touching that line. Verified with a real \`sphinx-build\` (full \`docs\` extra installed into an isolated venv): renders as "© Copyright 2020-present, Peter Corke: built 2026-08-03." in the built footer, no new warnings introduced.

## Test plan
- [x] Real \`sphinx-build\` run against these changes; footer renders correctly, no new build warnings
- [ ] N/A otherwise -- docs-only change, no code touched