### PR TITLE
test: fetch iread() URL-handling test image from GitHub, not petercorke.com

### DIFF
--- a/tests/base/test_io.py
+++ b/tests/base/test_io.py
@@ -53,7 +53,7 @@ class TestBaseImageIO(unittest.TestCase):
 
         # URL image
         try:
-            im = iread("https://petercorke.com/files/images/monalisa.png")
+            im = iread("https://raw.githubusercontent.com/petercorke/machinevision-toolbox-python/main/packages/mvtb-data/mvtbdata/images/monalisa.png")
         except (ValueError, urllib.error.URLError) as e:
             raise unittest.SkipTest(f"Network unavailable: {e}") from e
         self.assertIsInstance(im[0], np.ndarray)
@@ -608,7 +608,7 @@ class TestIreadAdvanced(unittest.TestCase):
         """Test iread with URL"""
         # This tests the URL loading path
         try:
-            im, filename = iread("https://petercorke.com/files/images/monalisa.png")
+            im, filename = iread("https://raw.githubusercontent.com/petercorke/machinevision-toolbox-python/main/packages/mvtb-data/mvtbdata/images/monalisa.png")
         except (ValueError, urllib.error.URLError) as e:
             raise unittest.SkipTest(f"Network unavailable: {e}") from e
         self.assertIsInstance(im, np.ndarray)


### PR DESCRIPTION
## Summary
- \`test_iread\` and \`test_iread_url_handling\` (\`tests/base/test_io.py\`) both fetch \`https://petercorke.com/files/images/monalisa.png\` over real HTTPS to exercise \`iread()\`'s URL-fetch path. This has been a repeated source of flaky CI failures this cycle -- PR #37 added a socket timeout so a slow/unavailable server fails fast instead of hanging, but that doesn't remove the dependency on that one personal server's uptime.
- Switched both to \`raw.githubusercontent.com\`, serving the identical image already tracked in this repo (\`packages/mvtb-data/mvtbdata/images/monalisa.png\` -- confirmed same \`(700, 677, 3)\` shape as the file the old URL served, so the existing assertions are unchanged). GitHub's raw content is CDN-backed, considerably more robust under CI load (many parallel matrix legs) than a single personal server, and since the file already lives in this repo there's no new dependency to maintain -- it's a staple MVTB test image that isn't going anywhere.

## Test plan
- [x] Both tests run and pass against the real new URL (not mocked)