### PR TITLE
ci: commit missing release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,64 @@
+{
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "python",
+    "packages": {
+        ".": {
+            "release-type": "python",
+            "package-name": "machinevision-toolbox-python",
+            "version-file": "pyproject.toml",
+            "changelog-path": "CHANGELOG.md",
+            "include-component-in-tag": false
+        }
+    },
+    "pull-request-title-pattern": "chore: release ${version}",
+    "changelog-sections": [
+        {
+            "type": "feat",
+            "section": "Features"
+        },
+        {
+            "type": "fix",
+            "section": "Bug Fixes"
+        },
+        {
+            "type": "perf",
+            "section": "Performance Improvements"
+        },
+        {
+            "type": "deps",
+            "section": "Dependencies"
+        },
+        {
+            "type": "revert",
+            "section": "Reverts"
+        },
+        {
+            "type": "docs",
+            "section": "Documentation"
+        },
+        {
+            "type": "build",
+            "section": "Build System"
+        },
+        {
+            "type": "test",
+            "section": "Tests",
+            "hidden": true
+        },
+        {
+            "type": "refactor",
+            "section": "Code Refactoring",
+            "hidden": true
+        },
+        {
+            "type": "chore",
+            "section": "Miscellaneous",
+            "hidden": true
+        },
+        {
+            "type": "ci",
+            "section": "CI",
+            "hidden": true
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- \`.github/workflows/release-please.yml\` requires \`release-please-config.json\` (\`config-file:\` input), but it was never actually committed to the repo -- only ever present as an untracked local file. Confirmed the automated release pipeline has been silently non-functional the entire time: zero release-please bot PRs have ever run, despite 39 merged PRs (including real \`feat:\` commits) since the last tag, \`v2.0.1\`.
- Already flagged as a sub-point in tech-debt issue #45 ("worth checking before cleanup, not after") -- this addresses that specific sub-point (the rest of #45, the untracked scratch/junk files, is unrelated and still open).
- Content is unchanged from the untracked working-tree copy: \`release-type: python\`, \`version-file: pyproject.toml\`, \`changelog-path: CHANGELOG.md\`, matching the existing (already-tracked) \`.release-please-manifest.json\` (\`"." : "2.0.1"\`).
- Merging this (a push to \`main\`) should itself trigger \`release-please.yml\` to run for the first time successfully, which should open its own auto-generated release PR for the next version.

Related to #45 (does not close it -- the untracked-scratch-files part of that issue is still open)

## Test plan
- [ ] Merge and confirm release-please's own workflow run succeeds and opens a release PR