### PR TITLE
fix: release-please never triggered the actual PyPI publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,12 +7,34 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please-action authenticates with GITHUB_TOKEN, and GitHub
+      # Actions doesn't let events triggered by GITHUB_TOKEN (like the
+      # `release` this action creates) start other workflows -- only
+      # workflow_dispatch/repository_dispatch are exempt from that
+      # anti-recursion rule. So dispatch release.yml explicitly here
+      # instead of relying on its `on: release: types: [created]` trigger,
+      # which never fires as a result.
+      #
+      # Must dispatch against the release tag, not the main branch: the
+      # `pypi` deploy environment's protection rules only allow deploys
+      # from refs matching `v*` (a tag), so `--ref main` gets rejected at
+      # the publish step even though build/smoke-test pass.
+      - name: Trigger PyPI publish
+        if: ${{ steps.release.outputs.releases_created }}
+        run: |
+          tag=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          gh workflow run release.yml --ref "$tag"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
`release.yml`'s `on: release: types: [created]` trigger has **never fired**, for any release — confirmed zero runs in its history, while PyPI was still sitting on `2.0.1` even though GitHub had already tagged `2.1.0` weeks ago and, as of this session, `2.2.0`.

Root cause: `release-please-action` authenticates with `GITHUB_TOKEN`, and GitHub Actions has a built-in anti-recursion rule where events triggered by `GITHUB_TOKEN` don't start other workflows — `workflow_dispatch`/`repository_dispatch` are the only exceptions. So the `release` event it creates silently never reached `release.yml`.

Fix: `release-please.yml` now explicitly dispatches `release.yml` (`gh workflow run`) against the new release's tag once `release-please-action` reports `releases_created`. Must target the tag specifically, not `main` — confirmed by testing that the `pypi` deploy environment's protection rules only allow deploys from refs matching `v*`; a branch-ref dispatch gets rejected at the publish step even though build/smoke-test pass.

`2.1.0` and `2.2.0` were both manually backfilled to PyPI via `workflow_dispatch` while diagnosing this — both are live now.

## Test plan
- [x] Manually dispatched `release.yml` against `v2.1.0` and `v2.2.0` tags — both built, smoke-tested, and published successfully (confirmed live via `pip index versions`)
- [x] Manually dispatched against `main` (branch ref) to confirm the failure mode this fix avoids — rejected by the `pypi` environment's tag-only deploy policy, as expected
- [x] YAML validated
- [ ] Real end-to-end validation of the new auto-dispatch step itself will happen the next time a release-please PR merges (can't rehearse `on: push: branches: [main]` + the actual release-please release-creation flow in isolation)