### PR TITLE
chore(gitignore): ignore bags directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dependencies*
 *.bag
 # but keep test fixtures
 !mvtb-data/mvtbdata/data/*.bag
+bags
 
 # old notebooks
 notebooks/old/*


### PR DESCRIPTION
## Summary
- Adds `bags` to `.gitignore`. This was your own uncommitted change from before this session's notebook-bootstrap work started — stashed at the time to keep it separate, applied now on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)