### PR TITLE
fix(ci): pass --repo to gh calls in release-please's PyPI-publish trigger

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Trigger PyPI publish
         if: ${{ steps.release.outputs.releases_created }}
         run: |
-          tag=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
-          gh workflow run release.yml --ref "$tag"
+          tag=$(gh release list --repo "$GH_REPO" --limit 1 --json tagName -q '.[0].tagName')
+          gh workflow run release.yml --repo "$GH_REPO" --ref "$tag"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- The "Trigger PyPI publish" step in `release-please.yml` has no `actions/checkout`, so `gh` can't infer the target repo from a git remote and fails with `fatal: not a git repository`.
- Pass `--repo` explicitly (via `GH_REPO` env) to both `gh release list` and `gh workflow run` so the step doesn't depend on git state at all.

Seen failing here: https://github.com/petercorke/machinevision-toolbox-python/actions/runs/31649562305

## Test plan
- [ ] Next `release-please` run that creates a release should successfully dispatch `release.yml` against the new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)