### PR TITLE
fix(ci): guard release-please's PyPI-publish trigger against the truthy-string bug

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,8 +31,14 @@ jobs:
       # `pypi` deploy environment's protection rules only allow deploys
       # from refs matching `v*` (a tag), so `--ref main` gets rejected at
       # the publish step even though build/smoke-test pass.
+      # release-please-action always sets releases_created to the literal
+      # string "true"/"false" (core.setOutput stringifies a JS boolean) --
+      # never unset. In an `if:` expression only "" is falsy, so a bare
+      # `${{ steps.release.outputs.releases_created }}` is truthy on every
+      # push, not just when a release was actually created. Must compare
+      # explicitly against the string 'true'.
       - name: Trigger PyPI publish
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
           tag=$(gh release list --repo "$GH_REPO" --limit 1 --json tagName -q '.[0].tagName')
           gh workflow run release.yml --repo "$GH_REPO" --ref "$tag"


### PR DESCRIPTION
## Summary
- `release-please-action` always sets `steps.release.outputs.releases_created` to the literal string `"true"` or `"false"` (it stringifies a JS boolean via `core.setOutput`), never leaves it unset.
- In a GitHub Actions `if:` expression, only `""`/`''` is falsy — any non-empty string, including `"false"`, is truthy. So `if: ${{ steps.release.outputs.releases_created }}` fired the "Trigger PyPI publish" step on **every** push to `main`, not just when a release was actually created.
- Confirmed live: after PR #73 merged (a non-release push, only updated the open release PR #66), this step still ran and dispatched `release.yml` against the already-published `v2.2.0` tag: https://github.com/petercorke/machinevision-toolbox-python/actions/runs/31653000797

## Fix
Compare explicitly against the string `'true'`.

## Test plan
- [ ] Next push to `main` that does NOT create a release should skip the trigger step.
- [ ] Next release-please PR merge (creates a real release) should still correctly dispatch `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)