### PR TITLE
fix: mvtbtool's %precision line spuriously echoes with --showassign

### DIFF
--- a/src/machinevisiontoolbox/bin/mvtbtool.py
+++ b/src/machinevisiontoolbox/bin/mvtbtool.py
@@ -391,7 +391,8 @@ def main():
     code = [
         f"%matplotlib{' '+args.backend if args.backend is not None else ''}",
         "import matplotlib.pyplot as plt",
-        "_precision = %precision %.3g;",
+        "_prec = get_ipython().run_line_magic('precision', '%.3g'); "
+        "print(f'Default numeric formatting: {_prec}')",
     ]
     if args.base:
         code.append("from machinevisiontoolbox.base import *")


### PR DESCRIPTION
## Summary
- `"_precision = %precision %.3g;"` relied on the trailing `;` to suppress output, but IPython's magic-line parsing swallows the entire rest of the line — including the `;` — into `%precision`'s own argument string, so it never actually functions as a suppression marker.
- This stays latent by default (plain assignments aren't auto-displayed under IPython's default `ast_node_interactivity`), but surfaces the moment `--showassign` is passed: `Out[1]: '%.3g;'` prints right before the first real prompt.
- Same class of bug just fixed in RTB's `rtbtool` (petercorke/robotics-toolbox-python#592), originally found while doing the equivalent fix in RVC3-python's `rvctool`.
- Fixed by wrapping the magic call in `get_ipython().run_line_magic(...)` and printing the result explicitly, so the line's last statement is a `print()` call — never auto-displayed regardless of `ast_node_interactivity`.

## Test plan
- [x] `mvtbtool` (default) — confirmed clean, shows `Default numeric formatting: %.3g`
- [x] `mvtbtool --showassign` — confirmed clean too (this was the case that actually triggered the bug before)
- [x] `pytest tests/test_bin.py` — 6 passed, 3 skipped (optional deps not installed)