### PR TITLE
ci: install open3d on one leg per supported Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           pip install "opencv-python==${{ matrix.opencv-version }}.*" "opencv-contrib-python==${{ matrix.opencv-version }}.*"
           cd packages/mvtb-data && pip install .
 
+      - name: Install open3d (one leg per supported Python version)
+        if: matrix.os == 'ubuntu-latest' && matrix.opencv-version == '5' && matrix.python-version != '3.13'
+        run: pip install open3d
+
       - name: Run tests
         env:
           MPLBACKEND: Agg


### PR DESCRIPTION
## Summary
- Completes the remaining part of #46. PR #78 fixed the stale `open3d-python` package name and added a `python_version<3.13` marker, but CI itself never installed open3d, so `test_pointcloud.py`'s and `test_bin.py`'s open3d-guarded coverage kept running skipped/degraded regardless of #78.
- open3d 0.19.0 ships wheels for cp310-cp312 only (confirmed via PyPI metadata, matching #78's marker) — installs it on `ubuntu-latest` for python-version 3.10-3.12, one leg per supported version. No new matrix axis, since (unlike opencv4-vs-5) there's no per-OS/version behavioural divergence in open3d to test for.

## Test plan
- [x] Verified locally in an isolated venv: with open3d installed, `test_pointcloud.py::test_constructor` and `test_bin.py`'s smoke test genuinely pass (785 passed/94 skipped vs 784/95 baseline without open3d — exactly the expected one-test delta), no regressions elsewhere
- [x] CI will exercise the real install on 3 of the 24 matrix legs

**Not fixed here:** `test_ros.py`'s open3d-gated pointcloud-publish tests remain skipped in CI — found they're also gated behind `roslibpy` (a separate `ros` extra, also never installed in CI), which open3d alone doesn't unlock. Filed as #80.

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)