### PR TITLE
fix: esttheta() -- broken pickregion() helper and missing theta-sweep body

### DIFF
--- a/src/machinevisiontoolbox/base/color.py
+++ b/src/machinevisiontoolbox/base/color.py
@@ -17,6 +17,7 @@ import matplotlib.path as mpath
 import matplotlib.pyplot as plt
 import numpy as np
 import spatialmath.base as smb
+from spatialmath import Polygon2
 from scipy import interpolate
 
 # import io as io
@@ -1777,8 +1778,8 @@ def shadow_invariant(
     return gs
 
 
-def esttheta(im: Any, sharpen: np.ndarray | None = None) -> None:
-    """
+def esttheta(im: Any, sharpen: np.ndarray | None = None) -> float:
+    r"""
     Estimate theta for shadow invariance
 
     :param im: input image
@@ -1790,24 +1791,27 @@ def esttheta(im: Any, sharpen: np.ndarray | None = None) -> None:
 
     This is an interactive procedure where the image is displayed and the user
     selects a region of homogeneous material (eg. grass or road) that includes
-    areas that are directly lit by the sun and in shadow.
+    areas that are directly lit by the sun and in shadow.  The invariant angle
+    θ is found by sweeping candidate angles and choosing the one that
+    minimizes the variance of the resulting invariant image over the selected
+    region -- at the true invariant angle, lit and shadowed pixels of the same
+    material map to (nearly) the same greyscale value.
 
     .. note:: The user selects boundary points by clicking the mouse. After the
         last point, hit the Enter key and the region will be closed.
+
+    :seealso: :func:`shadow_invariant`
     """
 
     def pickregion(im: Any) -> np.ndarray:
-        im.disp()
+        h = im.disp()
 
-        clicks = plt.ginput(n=-1)
+        clicks = h.figure.ginput(n=-1)
 
         xy = np.array(clicks)
-        print(xy)
 
-        smb.plot_poly(xy.T, "g", close=True)
-
-        polygon = smb.Polygon2(xy.T)
-        polygon.plot("g")
+        polygon = Polygon2(xy.T)
+        polygon.plot(color="g")
 
         X, Y = im.meshgrid()
         inside = polygon.contains(np.c_[X.ravel(), Y.ravel()].T)
@@ -1816,12 +1820,32 @@ def esttheta(im: Any, sharpen: np.ndarray | None = None) -> None:
 
     k_region = pickregion(im)
 
-    imcol = im.column()
-
+    imcol = im.view1d()
     z = imcol[k_region, :]
-    print(z.shape)
-    # k = find(in);
+    print(f"{z.shape[0]} pixels selected in the region")
+
+    theta_v = np.arange(0, np.pi, 0.02)
+    sim = np.empty_like(theta_v)
+    for i, θ in enumerate(theta_v):
+        gs = shadow_invariant(z.reshape(-1, 1, 3), θ, sharpen=sharpen).ravel()
+        bad = np.isinf(gs) | np.isnan(gs)
+        sim[i] = np.std(gs[~bad])
+
+    k = np.argmin(sim)
+    theta = theta_v[k]
+
+    plt.figure()
+    plt.plot(theta_v, sim)
+    plt.plot(theta, sim[k], "o")
+    plt.xlabel("invariant line angle (rad)")
+    plt.ylabel("invariance image variance")
+    plt.grid(True)
+
+    print(f"best angle = {theta:.4f} rad")
+
     _safe_show(block=True)
+
+    return theta
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

Multiple compounding bugs in `esttheta()`/`pickregion()`, all part of the same incomplete migration/port, found while root-causing RVC3-python's chap10.ipynb notebook test suite:

- `pickregion()` called `smb.plot_poly()` (removed from spatialmath-python) immediately before an already-migrated replacement two lines later (`Polygon2(...).plot(...)`) that draws the identical thing -- deleted the redundant broken leftover.
- The "already-migrated" replacement was itself broken: `smb.Polygon2` doesn't exist (`Polygon2` lives in top-level `spatialmath`, not `spatialmath.base`) -- added the import, matching every other call site in the codebase (`ImageConstants.py`, `Sources.py`, `ImageBlobs.py`, `ImageCore.py`, `tagtool.py` all do `from spatialmath import Polygon2`).
- `polygon.plot("g")` passed `"g"` positionally, binding to `Polygon2.plot`'s `ax` parameter (not color) -- a leftover calling convention from the old `plot_poly(xy, "g", close=True)` API. Fixed to `polygon.plot(color="g")`.
- `esttheta()`'s body never computed or returned theta at all -- only the interactive region-picking half of the original MATLAB function (`toolbox/esttheta.m`) was ported; the theta-sweep/variance-minimization loop was entirely missing, so the function always implicitly returned `None` despite its own docstring promising a `float`. Implemented the sweep using the already-ported `shadow_invariant()` (MVTB's existing Python port of MATLAB's `invariant()`/`shadowRemoval()`), matching the original algorithm: sweep theta in `[0, pi)`, compute the invariant image at each candidate angle, minimize `std()` over non-inf/nan pixels, return the best angle. Added a marker at the minimum and a grid to the diagnostic plot.
- `im.column()` -> `im.view1d()`: `column()` is already deprecated.
- `pickregion()` now calls `h.figure.ginput(...)` on the actual `Figure` handle returned by `im.disp()`, instead of the module-level `plt.ginput()` (which resolves its target through `gcf()`'s implicit global state). More robust regardless of backend.

**Note:** `ginput()`'s click events are not reliably delivered under `%matplotlib widget` (ipympl) in Jupyter -- this is a known, long-standing upstream ipympl limitation ([ipympl#400](https://github.com/matplotlib/ipympl/issues/400)), not something fixable here. Documented in the RVC3-python notebook as needing `%matplotlib tk`/`qt` for that specific cell.

## Test plan
- [x] Existing test suites (`tests/base/test_base_color.py`, `tests/test_image_color.py`) pass, no regressions
- [x] End-to-end headless test with a synthetic image and simulated clicks: region selection, theta sweep, and return value all verified correct
- [x] Verified live from `rvctool` and Jupyter against the real `parks.png` image (region picking, plotting, `h.figure.ginput()` fix)