### PR TITLE
fix: printstats() crashes if .stats hasn't been accessed yet

### DIFF
--- a/src/machinevisiontoolbox/ImageWholeFeatures.py
+++ b/src/machinevisiontoolbox/ImageWholeFeatures.py
@@ -285,7 +285,7 @@ class ImageWholeFeaturesMixin(_ImageBase if TYPE_CHECKING else object):
         :seealso: :meth:`stats`
         """
 
-        stats = self._stats
+        stats = self.stats
         if self.iscolor and self.colororder is not None:
             colororder = self.colororder
             for k in sorted(stats.keys(), key=lambda x: colororder[x]):

--- a/tests/test_image_whole_features.py
+++ b/tests/test_image_whole_features.py
@@ -314,6 +314,18 @@ class TestImageWholeFeatures(unittest.TestCase):
         # self.assertIn('mean', stats)
         # self.assertIn('std', stats)
 
+    def test_printstats_before_stats_accessed(self):
+        """printstats() must work on a fresh image, before .stats has ever
+        been accessed -- regression test: printstats() used to read the
+        private _stats cache directly instead of the .stats property, so
+        it crashed with the cache still None unless something had already
+        touched .stats first."""
+        im = Image.Random(size=(50, 50), dtype="uint8")
+        im.printstats()
+
+        color_im = Image.Random(size=(50, 50), colororder="RGB", dtype="uint8")
+        color_im.printstats()
+
     # new test
     def test_peaks(self):
         """Test peak finding in histogram"""


### PR DESCRIPTION
## Summary
- `printstats()` read the private `_stats` cache field directly instead of the `.stats` property. The cache is only populated by `.stats`'s own getter (`if self._stats is None: self._stats = ...`), so calling `printstats()` before `.stats` had ever been accessed hit `None` -> `TypeError`/`AttributeError`.
- Fixed by using `self.stats` instead, which computes and caches on first access.
- Found via RVC3-python's chap11.ipynb (`street.printstats()` etc., all called on freshly-loaded images -- the realistic, common case).
- Added a regression test that calls `printstats()` on a fresh image without touching `.stats` first -- the existing `test_stats()` always accessed `.stats` before any `printstats()` call would have run, which is why this shipped unnoticed.

## Test plan
- [x] New test fails against the pre-fix code with the exact original error (`TypeError: 'NoneType' object is not subscriptable`), passes with the fix
- [x] Full `tests/test_image_whole_features.py` suite passes (39 passed)