### PR TITLE
fix: Histogram.plot(type='ncdf') never actually worked, docstring lied

### DIFF
--- a/src/machinevisiontoolbox/ImageWholeFeatures.py
+++ b/src/machinevisiontoolbox/ImageWholeFeatures.py
@@ -1210,7 +1210,9 @@ class Histogram:
 
     def plot(
         self,
-        type: str = "frequency",
+        type: Literal[
+            "frequency", "pdf", "probability", "cf", "cumulative", "cdf", "normalized", "ncdf"
+        ] = "frequency",
         block: bool = False,
         filled: bool | None = None,
         stats: bool = True,
@@ -1227,8 +1229,9 @@ class Histogram:
         """
         Plot histogram
 
-        :param type: histogram type, one of: 'frequency' [default], 'cdf', 'ncdf'
-        :type type: str, optional
+        :param type: histogram type, one of: 'frequency' [default], 'pdf'/'probability',
+            'cf'/'cumulative', 'cdf'/'normalized'; 'ncdf' is accepted as a deprecated
+            alias for 'cdf'
         :param block: hold plot, defaults to False
         :type block: bool, optional
         :param filled: use a filled stairs plot, defaults to True for frequency plot, False for
@@ -1258,7 +1261,9 @@ class Histogram:
 
         Plots the histogram using Matplotlib.  For a color image, the histograms of each
         plane are plotted separately.  The ``type`` option selects the type of histogram
-        to plot: ``frequency``, ``cdf`` or ``ncdf`` (normalized cumulative in the range 0 to 1).
+        to plot: ``frequency``, ``pdf``/``probability``, ``cf``/``cumulative``, or
+        ``cdf``/``normalized`` (normalized cumulative, range 0 to 1).  ``ncdf`` is
+        accepted as a deprecated alias for ``cdf``.
 
         The ``style`` option selects the style for plotting multiple planes:
 
@@ -1341,6 +1346,14 @@ class Histogram:
             )
             if filled is None:
                 filled = bar
+
+        if type == "ncdf":
+            warnings.warn(
+                "Deprecated in 2.0.0: use type='cdf' instead of type='ncdf'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            type = "cdf"
 
         if type not in ("frequency", "pdf"):
             stats = False  # only show stats for frequency and pdf plot

--- a/tests/test_image_whole_features.py
+++ b/tests/test_image_whole_features.py
@@ -497,6 +497,21 @@ class TestImageWholeFeatures(unittest.TestCase):
             ncdf = h.ncdf
         nt.assert_array_equal(ncdf, h.cdf)
 
+    def test_plot_type_ncdf_deprecated_alias(self):
+        """Histogram.plot(type='ncdf') is a deprecated alias for
+        type='cdf' -- regression test: 'ncdf' was documented in plot()'s
+        own docstring but never actually implemented in the dispatch
+        logic, so it always raised ValueError('unknown type')."""
+        im = Image.Random(size=(50, 50), dtype="uint8")
+        h = im.hist()
+        with self.assertWarns(DeprecationWarning):
+            h.plot(type="ncdf")
+        plt.close("all")
+
+        # equivalent, current spelling -- must not warn
+        h.plot(type="cdf")
+        plt.close("all")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Resolves #39.

- `plot()`'s docstring claimed `'ncdf'` was an accepted `type` value, but the dispatch logic in `_compute_plot_series()` only ever handled `'frequency'`, `'pdf'`/`'probability'`, `'cf'`/`'cumulative'`, `'cdf'`/`'normalized'` -- `'ncdf'` always fell through to `raise ValueError("unknown type")`.
- **Resolution** (settles the open question in #39): `'ncdf'` (normalized CDF) is what `'cdf'`/`'normalized'` already means today -- a real CDF is normalized by definition, so the naming was simplified rather than the option being dropped by accident. This matches the existing `Histogram.ncdf` *property*, which is already a deprecated alias for `.cdf` with the identical pattern.
- Added `'ncdf'` as a matching deprecated string alias for `type='cdf'` in `plot()`, warning and normalizing before dispatch (same `DeprecationWarning` + `stacklevel=2` pattern already used for `plot()`'s `bar=` parameter, right above it in the same method).
- Fixed the docstring (both the `:param:` line and the prose) to list the real accepted values.
- Changed `type`'s annotation from plain `str` to a `Literal` enumerating the real values (including `'ncdf'` as a still-valid deprecated input) -- the exact resolution #39 itself suggested once the docstring/behavior mismatch was settled.

Found while working through RVC3-python's chap11.ipynb, which calls `h.plot("ncdf", color="blue")` per the printed book.

## Test plan
- [x] New regression test: `type='ncdf'` warns (`DeprecationWarning`) and produces the same plot as `type='cdf'`; fails against pre-fix code with the original `ValueError: unknown type`
- [x] Full `tests/test_image_whole_features.py` suite passes (39 passed)