### PR TITLE
fix: Image.metadata() missing camera-specific Exif sub-IFD tags

### DIFF
--- a/src/machinevisiontoolbox/ImageIO.py
+++ b/src/machinevisiontoolbox/ImageIO.py
@@ -267,6 +267,14 @@ class ImageIOMixin(_ImageBase if TYPE_CHECKING else object):
                 # map tag number to tag name
                 exif[TAGS[tag]] = value
 
+        # Camera-specific tags (FocalLength, ExposureTime, FNumber,
+        # ISOSpeedRatings, LensModel, ...) live in a separate "Exif" sub-IFD
+        # that Image.getexif() does not flatten into the top-level dict --
+        # 0x8769 is the fixed EXIF-spec tag id for the pointer to it.
+        for tag, value in meta.get_ifd(0x8769).items():
+            if tag in TAGS:
+                exif[TAGS[tag]] = value
+
         if key is None:
             return exif
         else:

--- a/tests/test_image_io.py
+++ b/tests/test_image_io.py
@@ -190,14 +190,23 @@ class TestImage(unittest.TestCase):
         # im.disp(block=False)
         pass
 
-    # new test
     def test_metadata(self):
         """Test reading image metadata"""
-        # TODO: Test with image file that has metadata
-        # im = Image.Read('test_image.jpg')
-        # metadata = im.metadata()
-        # self.assertIsNotNone(metadata)
-        pass
+        im = Image.Read("walls-l.png")
+        metadata = im.metadata()
+        self.assertIsNotNone(metadata)
+
+        # top-level IFD0 tags
+        self.assertEqual(metadata["Make"], "Apple")
+        self.assertEqual(metadata["Model"], "iPhone 5s")
+        self.assertEqual(im.metadata("Make"), "Apple")
+
+        # camera-specific tags live in a separate "Exif" sub-IFD that
+        # Image.getexif() doesn't flatten into the top-level dict --
+        # regression test for that sub-IFD merge
+        self.assertIn("FocalLength", metadata)
+        self.assertAlmostEqual(im.metadata("FocalLength"), 4.15)
+        self.assertAlmostEqual(metadata["FNumber"], 2.2)
 
     # new test
     def test_showpixels(self):


### PR DESCRIPTION
## Summary
- `Image.metadata("FocalLength")` (and `ExposureTime`, `FNumber`, `ISOSpeedRatings`, `LensModel`, ...) always raised `KeyError`, even though the tag is genuinely present in the file.
- Root cause: `Image.getexif()` (the modern public Pillow API) only returns the top-level IFD0 tags (`Make`, `Model`, `Orientation`, ...). Camera-specific tags live in a separate "Exif" sub-IFD that `getexif()` does not flatten in -- needs an explicit `Exif.get_ifd(0x8769)` call (`0x8769` is the fixed EXIF-spec tag id for the Exif IFD pointer).
- This is a Pillow API evolution, not a data problem: the old private `Image._getexif()` used to flatten everything into one dict; the public `getexif()` deliberately does not.
- Fix merges the sub-IFD tags into the returned dict alongside the top-level ones.

## Test plan
- [x] `tests/test_image_io.py::TestImage::test_metadata` -- was a stub (`pass`), now exercises both top-level (`Make`, `Model`) and sub-IFD (`FocalLength`, `FNumber`) tags against the bundled `walls-l.png` fixture (real iPhone 5s EXIF data)
- [x] Full test suite: 816 passed, 72 skipped, no regressions
- [x] Manually verified against RVC3-python's chap14.ipynb notebook cells (`f = walls_l.metadata("FocalLength")`, `f = notredame.metadata("FocalLength")`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)