### PR TITLE
fix: PointCloud.Read() double-joins a caller-supplied "data/" prefix

### DIFF
--- a/src/machinevisiontoolbox/PointCloud.py
+++ b/src/machinevisiontoolbox/PointCloud.py
@@ -2,6 +2,7 @@
 Thin wrapper around Open3D point-cloud objects with MVTB look and feel.
 """
 
+from pathlib import Path
 from warnings import warn
 from typing import Any, Callable
 
@@ -244,9 +245,21 @@ class PointCloud:
         the ``data`` folder of the
         `mvtb_data package <https://github.com/petercorke/machinevision-toolbox-python/tree/master/packages/mvtb-data>`_.
 
+        .. note:: ``filename`` may be given as a bare name (``'bunny.ply'``)
+            or with a redundant leading ``data/`` (``'data/bunny.ply'``, the
+            older convention some book examples still use) -- both resolve
+            to the same file.
+
         """
 
         from machinevisiontoolbox import mvtb_path_to_datafile
+
+        # accept a caller-supplied redundant "data/" prefix (older
+        # convention) without double-joining it against the "data" this
+        # method already prepends
+        parts = Path(filename).parts
+        if parts and parts[0] == "data":
+            filename = str(Path(*parts[1:])) if len(parts) > 1 else ""
 
         filename = mvtb_path_to_datafile("data", filename, string=True)
         pcd = o3d.io.read_point_cloud(filename, *args, **kwargs)

--- a/tests/test_pointcloud.py
+++ b/tests/test_pointcloud.py
@@ -39,6 +39,18 @@ class TestPointCloud(unittest.TestCase):
         rgbd = Image.Pstack((d, rgb.astype("uint16")), colororder="DRGB")
         pc = PointCloud.DepthImage(rgbd, camera)
 
+    def test_read(self):
+        # bare filename -- the documented convention
+        pc = PointCloud.Read("bunny.ply")
+        self.assertIsInstance(pc, PointCloud)
+        self.assertEqual(len(pc), 35947)
+
+        # a caller-supplied redundant "data/" prefix (the older convention
+        # some book examples still use) must resolve to the same file,
+        # not double-join to data/data/bunny.ply
+        pc2 = PointCloud.Read("data/bunny.ply")
+        self.assertEqual(len(pc2), len(pc))
+
 
 # ----------------------------------------------------------------------- #
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `PointCloud.Read('data/bunny.ply')` fails with `ValueError: file ('data', 'data/bunny.ply') not found locally or in mvtbdata`, even though `mvtbdata/data/bunny.ply` genuinely exists in the installed package.
- Root cause: `Read()` hardcodes `"data"` as the `mvtbdata` subfolder via `mvtb_path_to_datafile("data", filename)`. The documented/intended convention is a bare filename (`PointCloud.Read('bunny.ply')`), but both of the book's own figure-generation scripts (`figures/code/chapter14/fig14_43.py`, `fig14_44.py`) call `Read('data/bunny.ply')` with a redundant `data/` prefix -- an older convention that predates `mvtb_path_to_datafile`'s current auto-prefixing design. That redundant prefix makes the lookup search for `mvtbdata/data/data/bunny.ply`, which doesn't exist.
- Fix strips a leading `data` path component before joining, so both forms resolve to the same file -- keeps the book's existing example scripts working without requiring readers to edit them.

## Test plan
- [x] `tests/test_pointcloud.py::TestPointCloud::test_read` (new) -- covers both `Read('bunny.ply')` and `Read('data/bunny.ply')`, asserts identical point count
- [x] Full test suite: 820 passed, 71 skipped, no regressions
- [x] Manually verified against RVC3-python's chap14.ipynb notebook (`bunny_pcd = PointCloud.Read('bunny.ply')`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)