### PR TITLE
fix: name2color() colororder reordering returns list, not ndarray

### DIFF
--- a/src/machinevisiontoolbox/base/color.py
+++ b/src/machinevisiontoolbox/base/color.py
@@ -815,8 +815,10 @@ def name2color(
                 color = (color * np.iinfo(dtype).max).astype(dtype)
             if colororder is not None:
                 # reorder the elements of the color if colororder is given
-                # colororder is a dict mapping plane name to index
-                color = [color[colororder[c]] for c in colorspace]
+                # colororder is a dict mapping plane name to index -- fancy
+                # index rather than a list comprehension, to keep the
+                # ndarray return type promised by this function's contract
+                color = color[[colororder[c] for c in colorspace]]
             return color
         except ValueError:
             return None

--- a/tests/base/test_base_color.py
+++ b/tests/base/test_base_color.py
@@ -145,7 +145,20 @@ class TestColor(unittest.TestCase):
         # Test different color spaces
         g_xy = color.name2color('g', 'xy')
         self.assertEqual(len(g_xy), 2)
-    
+
+    def test_name2color_colororder(self):
+        """colororder= must still return an ndarray, not a list -- regression
+        test for a bug where the reordering used a list comprehension and
+        silently dropped the ndarray return type"""
+        red_rgb = color.name2color('red', colororder={'R': 0, 'G': 1, 'B': 2})
+        self.assertIsInstance(red_rgb, np.ndarray)
+        nt.assert_array_almost_equal(red_rgb, [1, 0, 0])
+
+        # reordered: B first, so red's 1.0 moves to the last position
+        red_bgr = color.name2color('red', colororder={'B': 0, 'G': 1, 'R': 2})
+        self.assertIsInstance(red_bgr, np.ndarray)
+        nt.assert_array_almost_equal(red_bgr, [0, 0, 1])
+
     def test_colorname(self):
         """Test color to name conversion"""
         # Test basic lookup

--- a/tests/test_image_point_features.py
+++ b/tests/test_image_point_features.py
@@ -197,6 +197,18 @@ class TestImagePointFeatures(unittest.TestCase):
         except:
             pass
 
+    def test_draw2(self):
+        """draw2() with a named color and a colorized (colororder-bearing)
+        image must not raise -- regression test for name2color() leaking a
+        plain list instead of an ndarray when colororder is given"""
+        img = Image.Read("monalisa.png", mono=True)
+        orb = img.ORB(nfeatures=20)
+        self.assertGreater(len(orb), 0)
+
+        color_img = img.colorize()
+        result = orb.draw2(color_img, color="y")
+        self.assertIsInstance(result, Image)
+
     def test_features_list_operations(self):
         """Test feature list operations"""
         img = Image.Read("monalisa.png", mono=True)


### PR DESCRIPTION
## Summary
- `BaseFeature2D.draw2(image, color='y')` crashes with `AttributeError: 'list' object has no attribute 'flat'` whenever `image` has a real `colororder` (e.g. from `.colorize()`).
- Root cause: `name2color()`'s `colororder` reordering (`color = [color[colororder[c]] for c in colorspace]`) uses a list comprehension, which silently converts the ndarray return value into a plain Python `list`. Every other caller of `name2color()` (and its own docstring `:rtype:`) expects an ndarray for the numeric-lookup case -- the documented `list[str]` return is a completely different mode (wildcard color-name search via a regex `name`), so this was an undocumented third return shape introduced by accident.
- `draw2()` is the only caller that ever passes `colororder=` (checked all call sites), and it does `color_ndarray.flat[0]` etc. on the result.
- Fix: fancy-index (`color[[colororder[c] for c in colorspace]]`) instead of a list comprehension, preserving the ndarray type -- matches what every other caller already assumes.

## Test plan
- [x] `tests/base/test_base_color.py::TestColor::test_name2color_colororder` (new) -- asserts `ndarray` return type and correct reordering for both RGB and BGR colororders
- [x] `tests/test_image_point_features.py::TestImagePointFeatures::test_draw2` (new) -- exercises the actual originally-failing call path end-to-end (ORB features drawn onto a colorized image)
- [x] Full test suite: no regressions
- [x] Manually verified against RVC3-python's chap14.ipynb notebook (visual odometry section, `features.draw2(image, color='y')`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)