### PR TITLE
fix: idisp() crashes when reuse=True with no title given

### DIFF
--- a/src/machinevisiontoolbox/base/imageio.py
+++ b/src/machinevisiontoolbox/base/imageio.py
@@ -882,10 +882,15 @@ def idisp(
         ## display using OpenCV
         global __last_window_number
 
-        if not reuse and title is None:
-            # create a unique window name for each call
-            title = "idisp." + str(__last_window_number)
-            __last_window_number += 1
+        if title is None:
+            if reuse:
+                # fixed name (no counter) so repeated calls in an
+                # animation loop share the same window
+                title = "idisp"
+            else:
+                # create a unique window name for each call
+                title = "idisp." + str(__last_window_number)
+                __last_window_number += 1
 
         # At this point title is guaranteed to be a string
         assert title is not None

--- a/tests/base/test_io.py
+++ b/tests/base/test_io.py
@@ -369,6 +369,20 @@ class TestIdisp(unittest.TestCase):
         result = idisp(im, matplotlib=False)
         self.assertIsNone(result)
 
+    def test_idisp_reuse_no_title(self):
+        """reuse=True with no title must not crash -- regression test for
+        the OpenCV path's title fallback (previously asserted title is not
+        None even though reuse=True skipped generating one)"""
+        from machinevisiontoolbox.base.imageio import cv_destroy_window, idisp
+
+        im = np.random.randint(0, 256, (30, 30), dtype=np.uint8)
+
+        try:
+            idisp(im, matplotlib=False, reuse=True)
+            idisp(im, matplotlib=False, reuse=True)
+        finally:
+            cv_destroy_window("idisp", block=False)
+
     def test_idisp_float_image(self):
         """Test idisp with float image"""
         im = np.random.rand(30, 30).astype(np.float32)


### PR DESCRIPTION
## Summary
- `Image.disp(reuse=True, matplotlib=False)` with no `title=` given crashes with a bare `AssertionError`, instead of opening/reusing a window.
- Root cause: the OpenCV display path only auto-generates a window title when `reuse=False` (`if not reuse and title is None: ...`). With `reuse=True` and no explicit `title`, `title` stays `None`, and the very next line's `assert title is not None` (added later, with a comment claiming this was already guaranteed -- it wasn't, for this exact case) fails.
- `reuse=True` is meant for an animation loop redrawing into the same window across many calls, so the fallback can't be the existing counter-incremented `"idisp.N"` naming (that opens a new window per call, defeating `reuse`). Uses a fixed generic title instead, so repeated calls without an explicit title still share one window.

## Test plan
- [x] `tests/base/test_io.py::TestIdisp::test_idisp_reuse_no_title` (new) -- two consecutive `reuse=True` calls with no title, must not raise
- [x] Full test suite: no regressions
- [x] Manually verified against RVC3-python's chap14.ipynb notebook (visual odometry loop, `image.disp(reuse=True, fps=20, matplotlib=False)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)