### PR TITLE
fix: remove dead numpy.char.array import triggering chararray deprecation

### DIFF
--- a/src/machinevisiontoolbox/Sources.py
+++ b/src/machinevisiontoolbox/Sources.py
@@ -25,7 +25,6 @@ import warnings
 import zipfile
 from collections import Counter, deque
 from collections.abc import Iterator
-from numpy.char import array
 from tqdm import tqdm
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, IO, Any, Literal, cast


### PR DESCRIPTION
## Summary
- `from numpy.char import array` at `Sources.py:28` was unused -- confirmed via `grep -n "[^.]\barray(" src/machinevisiontoolbox/Sources.py`, which returns zero hits. Every real `array(...)` call in the file is `np.array(...)` (a different function) or a local variable that happens to be named `array`.
- The import served no purpose and only existed to trigger numpy's `"The chararray class is deprecated"` `DeprecationWarning` on every import of the package -- visible throughout the test suite's warning summary.

## Fix
Delete the unused import. No behavior change.

## Test plan
- [x] Confirmed the warning no longer fires on `import machinevisiontoolbox.Sources` (captured via `warnings.catch_warnings`).
- [x] Full test suite: 1001 passed, 15 skipped, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)