### PR TITLE
fix: exclude tests/ from Bandit's assert_used (B101) check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,14 @@ select = ["E", "F", "I"]
 [tool.ruff.lint.isort]
 known-first-party = ["machinevisiontoolbox"]
 
+[tool.bandit]
+# bare `assert` is idiomatic pytest style, not a security concern -- Bandit's
+# B101 ("assert used") is meant for src/, where assert can silently vanish
+# under `python -O`. Excluding tests/ keeps that check meaningful without
+# flagging every test assertion (Codacy runs Bandit via Prospector and
+# honours this file).
+exclude_dirs = ["tests"]
+
 [tool.pyright]
 include = ["src"]
 ignore = ["docs", "tests", "examples"]


### PR DESCRIPTION
## Summary
Codacy has been flagging every bare `assert` in the test suite (Prospector's Bandit integration, rule B101 "assert_used"). Bare `assert` is idiomatic pytest style (~45 uses across `tests/`), not a security concern there -- B101 exists to catch `assert` used for real validation in `src/`, where an assert can silently vanish under `python -O`. That's still a legitimate 48 findings, untouched by this change (tracked in #41).

## Fix
```toml
[tool.bandit]
exclude_dirs = ["tests"]
```
Codacy's Python engine is Prospector, which wraps Bandit and honours this native `pyproject.toml` config directly -- no Codacy dashboard setting needed.

## Verified
Throwaway venv, `bandit -c pyproject.toml -r src tests`:
- Before this config: 93 B101 findings (48 in `src/`, 45 in `tests/`)
- After: 48 -- identical to `-r src` alone. `tests/`'s contribution is fully suppressed, `src/`'s is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)