### PR TITLE
fix: assert hygiene -- unreachable assert, two caller-facing checks

### DIFF
--- a/src/machinevisiontoolbox/BundleAdjust.py
+++ b/src/machinevisiontoolbox/BundleAdjust.py
@@ -405,7 +405,8 @@ if pgraph_installed:
 
             :seealso: :meth:`add_view` :meth:`add_landmark`
             """
-            assert len(uv) == 2, "uv must be a 2-vector"
+            if len(uv) != 2:
+                raise ValueError("uv must be a 2-vector")
 
             edge = Observation(viewpoint, landmark, uv.flatten())  # create edge object
             e = viewpoint.connect(landmark, edge=edge)  # connect nodes with it

--- a/src/machinevisiontoolbox/Camera.py
+++ b/src/machinevisiontoolbox/Camera.py
@@ -350,7 +350,8 @@ class CameraBase(ABC):
 
         :seealso: :meth:`nv` :meth:`width` :meth:`imagesize`
         """
-        assert self._imagesize is not None, "imagesize not set"
+        if self._imagesize is None:
+            raise ValueError("imagesize not set")
         return self._imagesize[0]
 
     @property
@@ -370,7 +371,8 @@ class CameraBase(ABC):
 
         :seealso: :meth:`nu` :meth:`height`  :meth:`imagesize`
         """
-        assert self._imagesize is not None, "imagesize not set"
+        if self._imagesize is None:
+            raise ValueError("imagesize not set")
         return self._imagesize[1]
 
     @property
@@ -390,7 +392,8 @@ class CameraBase(ABC):
 
         :seealso: :meth:`nu` :meth:`height`
         """
-        assert self._imagesize is not None, "imagesize not set"
+        if self._imagesize is None:
+            raise ValueError("imagesize not set")
         return self._imagesize[0]
 
     @property
@@ -410,7 +413,8 @@ class CameraBase(ABC):
 
         :seealso: :meth:`nv` :meth:`width`
         """
-        assert self._imagesize is not None, "imagesize not set"
+        if self._imagesize is None:
+            raise ValueError("imagesize not set")
         return self._imagesize[1]
 
     @property

--- a/src/machinevisiontoolbox/Sources.py
+++ b/src/machinevisiontoolbox/Sources.py
@@ -2348,7 +2348,7 @@ class ROSTopic(ImageSource):
                 "Install it with: pip install open3d "
                 "or pip install machinevision-toolbox-python[open3d]"
             )
-            assert o3d is not None
+        assert o3d is not None
 
         points = np.asarray(pc._pcd.points)
         if points.ndim != 2 or points.shape[1] != 3:


### PR DESCRIPTION
## Summary
Found while surveying `src/`'s ~48 Bandit B101 ("assert used") findings (see #99, which excludes `tests/` from that check but leaves `src/`'s real findings active). Most are legitimate -- type-narrowing right after a prior check, or optional-dependency guards immediately following an `ImportError` raise -- and are staying as-is. Three were real issues:

- **`Sources.py`** (PointCloud publish support): `assert o3d is not None` sat *inside* the `if not _open3d_available: raise ImportError(...)` block, after the `raise` -- unreachable dead code. Apparently a mis-indented copy of the same pattern used correctly at 7 other call sites in this file. Dedented to match them.
- **`BundleAdjust.py`**: `add_projection()`'s `assert len(uv) == 2, "uv must be a 2-vector"` validates a caller-supplied argument on a public method, not an internal invariant -- converted to `if len(uv) != 2: raise ValueError(...)` so it survives `python -O` instead of silently vanishing.
- **`Camera.py`**: `nu`/`nv`/`width`/`height` each asserted `self._imagesize is not None, "imagesize not set"` -- a real "you called this before configuring the camera" caller mistake (the informative message was the tell), not an internal invariant. Converted to `if self._imagesize is None: raise ValueError(...)`, matching the existing `raise ValueError("imagesize or rho properties not set")` convention already used elsewhere in this file (`Camera.py:1900`).

## Test plan
- [x] Full test suite: 1010 passed, 15 skipped, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)