### PR TITLE
fix: catch cv2.error in points2F(), not just F/mask=None

### DIFF
--- a/src/machinevisiontoolbox/Camera.py
+++ b/src/machinevisiontoolbox/Camera.py
@@ -2785,9 +2785,20 @@ class CentralCamera(CameraBase):
         if seed is not None:
             cv2.setRNGSeed(seed)
 
-        F, mask = cv2.findFundamentalMat(
-            points1=p1.T, points2=p2.T, method=points2F_dict[method], **kwargs
-        )
+        try:
+            F, mask = cv2.findFundamentalMat(
+                points1=p1.T, points2=p2.T, method=points2F_dict[method], **kwargs
+            )
+        except cv2.error as e:
+            # on some degenerate point configurations cv2.findFundamentalMat
+            # raises a raw C++ assertion (eg. a Mat rowRange error) instead
+            # of returning None -- same underlying cause as the F is None
+            # case below, just surfaced differently by OpenCV
+            raise ValueError(
+                f"cv2.findFundamentalMat could not estimate F from "
+                f"{p1.shape[1]} point correspondences using method={method!r} "
+                f"-- points are likely too degenerate (eg. coplanar, collinear): {e}"
+            ) from e
 
         if F is None or mask is None:
             # already know p1.shape[1] >= min_points (checked above), so a


### PR DESCRIPTION
## Summary
- \`points2F()\` already handles \`cv2.findFundamentalMat()\` returning \`(None, None)\` on degenerate point configurations, converting it to a descriptive \`ValueError\`. But OpenCV doesn't always fail that cleanly -- on some inputs it raises a raw C++ assertion instead (\`Assertion failed: 0 <= _rowRange.start && ... in function 'Mat'\`), which isn't caught anywhere.
- Catches \`cv2.error\` alongside the existing \`None\` check and re-raises as the same \`ValueError\`, since it's the same underlying cause (degenerate points), just surfaced differently by OpenCV.
- Found via RVC3-python's \`visodom.py\` example, a temporal visual-odometry loop that already wraps \`estimate(cam.points2F, ...)\` in \`try/except ValueError\` specifically to skip degenerate frames -- the raw \`cv2.error\` was slipping past that except clause and crashing the whole run at frame 149 of 251.

## Test plan
- [x] \`pytest tests/ -k "points2F or Camera or camera"\` -- 27 passed, 1 skipped
- [x] Ran RVC3-python's \`visodom.py\` end to end against the bridge dataset (251 frames) -- previously crashed hard at frame 149, now cleanly skips it and completes all 251 frames